### PR TITLE
Update GitHub Actions to replace "actions-rs"

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,3 @@
-# source: https://gist.github.com/PurpleBooth/84b3d7d6669f77d5a53801a258ed269a
 name: CI
 
 on:
@@ -22,78 +21,39 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/cache@v3
+      - uses: Swatinem/rust-cache@v2
+      - name: Rust latest stable
+        uses: dtolnay/rust-toolchain@master
         with:
-          path: ~/.cargo/registry
-          key: '${{ runner.os }}-cargo-registry-${{ hashFiles(''**/Cargo.lock'') }}'
-      - uses: actions/cache@v3
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-      - name: 'install toolchain'
-        uses: actions-rs/toolchain@v1.0.7
-        with:
-          profile: minimal
           toolchain: stable
-          override: true
-      - name: 'check dependencies'
-        uses: actions-rs/cargo@v1.0.3
-        with:
-          command: check
-          args: '--all-targets'
-      - name: 'run "cargo deny check"'
+      - name: check dependencies
+        run: cargo check --all-targets
+      - name: run "cargo deny check"
         uses: EmbarkStudios/cargo-deny-action@v1.3.2
 
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/cache@v3
+      - uses: Swatinem/rust-cache@v2
+      - name: Rust latest stable
+        uses: dtolnay/rust-toolchain@master
         with:
-          path: ~/.cargo/registry
-          key: '${{ runner.os }}-cargo-registry-${{ hashFiles(''**/Cargo.lock'') }}'
-      - uses: actions/cache@v3
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-      - name: 'install toolchain'
-        uses: actions-rs/toolchain@v1.0.7
-        with:
-          profile: minimal
           toolchain: stable
-          override: true
-          components: 'rustfmt, clippy'
-      - name: 'run rustfmt'
-        uses: actions-rs/cargo@v1.0.3
-        with:
-          command: fmt
-          args: '--all -- --check'
-      - name: 'run clippy'
-        uses: actions-rs/cargo@v1.0.3
-        with:
-          command: clippy
-          args: '--all-targets -- -D warnings'
+          components: clippy,rustfmt
+      - name: run rustfmt
+        run: cargo fmt --all -- --check
+      - name: run clippy
+        run: cargo clippy --all-targets -- -D warnings
 
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/cache@v3
+      - uses: Swatinem/rust-cache@v2
+      - name: Rust latest stable
+        uses: dtolnay/rust-toolchain@master
         with:
-          path: ~/.cargo/registry
-          key: '${{ runner.os }}-cargo-registry-${{ hashFiles(''**/Cargo.lock'') }}'
-      - uses: actions/cache@v3
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-      - name: 'install toolchain'
-        uses: actions-rs/toolchain@v1.0.7
-        with:
-          profile: minimal
           toolchain: stable
-          override: true
-      - name: 'run tests'
-        uses: actions-rs/cargo@v1.0.3
-        with:
-          command: test
-          args: '--all-targets'
+      - name: run tests
+        run: cargo test --all-targets


### PR DESCRIPTION
This PR contains all relevant changes to replace the "actions-rs/*" actions (which are seemingly outdated) with similar action(s).