### PR TITLE
New crate version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.4.1
+
+* updated dependency [base64](https://crates.io/crates/base64) to version `0.21`
+
 # v0.4
 
 * removed `TcModel` (obsolete since there is only one version, use `TcModelV2::try_from` instead)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,7 +270,7 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lib_tcstring"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "base64",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lib_tcstring"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Joerg Jennerjahn <joerg.jennerjahn@advanced-store.com>", "Friedemann Sommer <friedemann.sommer@advanced-store.com>"]
 edition = "2018"
 description = "IAB TCF v2 TCString utilities"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Crates.io license](https://img.shields.io/crates/l/lib_tcstring?style=flat-square)
 ![Crates.io version](https://img.shields.io/crates/v/lib_tcstring?style=flat-square)
-![GitHub Workflow Status](https://img.shields.io/github/workflow/status/advancedSTORE/lib_tcstring/CI?style=flat-square)
+![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/advancedSTORE/lib_tcstring/rust.yml?style=flat-square&branch=master)
 ![dependency status for latest release](https://img.shields.io/librariesio/release/cargo/lib_tcstring?style=flat-square)
 
 # IAB TCString library
@@ -25,7 +25,7 @@ For major (or breaking) version changes see [CHANGELOG.md](./CHANGELOG.md)
 
 ```toml
 [dependencies]
-lib_tcstring = "0.4.0"
+lib_tcstring = "0.4.1"
 ```
 
 Code

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //! ```
 
 #![warn(clippy::all)]
-#![doc(html_root_url = "https://docs.rs/lib_tcstring/0.4.0")]
+#![doc(html_root_url = "https://docs.rs/lib_tcstring/0.4.1")]
 #![warn(missing_docs)]
 #![forbid(unsafe_code)]
 


### PR DESCRIPTION
This PR bumps the crate to `0.4.1` to update the [base64](https://crates.io/crates/base64) dependency.